### PR TITLE
chore: ignore docs as releasable units

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -13,7 +13,7 @@
         {"type": "fix", "section": "🐛 Bug Fixes", "hidden": false},
         {"type": "perf", "section": "⚡ Performance Improvements", "hidden": false},
         {"type": "revert", "section": "⏪ Reverts", "hidden": false},
-        {"type": "docs", "section": "📚 Documentation", "hidden": false},
+        {"type": "docs", "section": "📚 Documentation", "hidden": true},
         {"type": "style", "section": "💄 Styles", "hidden": false},
         {"type": "refactor", "section": "♻️ Code Refactoring", "hidden": false},
         {"type": "build", "section": "🔧 Build System", "hidden": false},


### PR DESCRIPTION
This stops release-please trying to release documentation updates (not compiled and not required in the changelog imo)