### PR TITLE
feat: add resurrectable sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3000,7 @@ version = "0.1.0"
 dependencies = [
  "dirs 6.0.0",
  "fuzzy-matcher",
+ "humantime",
  "serde",
  "uuid",
  "zellij-tile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1.0.164", features = ["derive"] }
 fuzzy-matcher = "0.3.7"
 uuid = { version = "1.8.0", features = ["v4"] }
 dirs = "6.0.0"
+humantime = "2.2.0"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ keybinds clear-defaults=true {
             
                 // Session name separator (default: ".")
                 session_separator "_"
+                
+                // Show sessions that can be resurrected
+                show_resurrectable_sessions true
             }
         }
     }
@@ -87,10 +90,11 @@ keybinds clear-defaults=true {
 
 ### Configuration Options
 
-| Option              | Description                               | Default | Example         |
-|---------------------|-------------------------------------------|---------|-----------------|
-| `default_layout`    | Layout name for Ctrl+Enter quick creation | None    | `"development"` |
-| `session_separator` | Character used in session names           | `"."`   | `"-"` or `"_"`  |
+| Option                        | Description                               | Default | Example         |
+|-------------------------------|-------------------------------------------|---------|-----------------|
+| `default_layout`              | Layout name for Ctrl+Enter quick creation | None    | `"development"` |
+| `session_separator`           | Character used in session names           | `"."`   | `"-"` or `"_"`  |
+| `show_resurrectable_sessions` | Show sessions that can be resurrected     | `false` | `true`          |
 
 ## 🎯 How It Works
 
@@ -117,7 +121,7 @@ ZSM automatically generates meaningful session names:
 ### 3. Session Integration
 
 - **Existing sessions** are shown with indicators: `● current` or `○ available`
-- **Both sessions AND directories** are displayed for complete context
+- **Resurrectable sessions** (if enabled) are shown with a `↺` icon
 - **Auto-increment**: If session `webapp` exists, creates `webapp.2`, `webapp.3`, etc.
 
 ### 4. Quick Workflows

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,8 @@ pub struct Config {
     pub default_layout: Option<String>,
     /// Separator used in session names (default: ".")
     pub session_separator: String,
+    /// Whether you'd like resurrectable sessions to be shown in the session list
+    pub show_resurrectable_sessions: bool,
 }
 
 impl Default for Config {
@@ -14,6 +16,7 @@ impl Default for Config {
         Self {
             default_layout: None,
             session_separator: ".".to_string(),
+            show_resurrectable_sessions: false,
         }
     }
 }
@@ -27,6 +30,10 @@ impl Config {
                 .get("session_separator")
                 .cloned()
                 .unwrap_or_else(|| ".".to_string()),
+            show_resurrectable_sessions: config
+                .get("show_resurrectable_sessions")
+                .map(|v| v == "true")
+                .unwrap_or(false),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ mod zoxide;
 
 use zellij_tile::prelude::*;
 use std::collections::BTreeMap;
-
 use state::PluginState;
 use ui::PluginRenderer;
 
@@ -61,8 +60,9 @@ impl ZellijPlugin for PluginState {
                     }
                 }
             }
-            Event::SessionUpdate(session_infos, _) => {
+            Event::SessionUpdate(session_infos, resurrectable_session_infos) => {
                 self.update_sessions(session_infos);
+                self.update_resurrectable_sessions(resurrectable_session_infos);
                 should_render = true;
             }
             Event::RunCommandResult(exit_code, stdout, stderr, context) => {

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use zellij_tile::prelude::{SessionInfo, kill_sessions, switch_session};
 use crate::session::types::SessionAction;
 
@@ -8,6 +9,8 @@ pub struct SessionManager {
     sessions: Vec<SessionInfo>,
     /// Session name pending deletion confirmation
     pending_deletion: Option<String>,
+    /// Resurrectable sessions
+    resurrectable_sessions: Vec<(String, Duration)>,
 }
 
 impl SessionManager {
@@ -16,10 +19,21 @@ impl SessionManager {
         self.sessions = sessions;
     }
 
+    /// Update the resurrectable sessions
+    pub fn update_resurrectable_sessions(&mut self, resurrectable_sessions: Vec<(String, Duration)>) {
+        self.resurrectable_sessions = resurrectable_sessions;
+    }
+
     /// Get all sessions
     pub fn sessions(&self) -> &[SessionInfo] {
         &self.sessions
     }
+    
+    /// Get all resurrectable sessions
+    pub fn resurrectable_sessions(&self) -> &[(String, Duration)] {
+        &self.resurrectable_sessions
+    }
+
 
     /// Execute a session action
     pub fn execute_action(&mut self, action: SessionAction) {

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -8,6 +8,11 @@ pub enum SessionItem {
         directory: String,
         is_current: bool,
     },
+    /// A resurrectable session that can be restored
+    ResurrectableSession {
+        name: String,
+        duration: std::time::Duration,
+    },
     /// A zoxide directory that can be used to create a new session
     Directory {
         path: String,
@@ -19,6 +24,9 @@ impl SessionItem {
     /// Check if this is an existing session
     pub fn is_session(&self) -> bool {
         matches!(self, SessionItem::ExistingSession { .. })
+    }
+    pub fn is_resurrectable_session(&self) -> bool {
+        matches!(self, SessionItem::ResurrectableSession { .. })
     }
 }
 

--- a/src/zoxide/search.rs
+++ b/src/zoxide/search.rs
@@ -146,9 +146,9 @@ impl SearchEngine {
 
         // Sort results: sessions first, then by score
         matches.sort_by(|a, b| {
-            let a_is_session = a.item.is_session();
-            let b_is_session = b.item.is_session();
-            
+            let a_is_session = a.item.is_session() || a.item.is_resurrectable_session();
+            let b_is_session = b.item.is_session() || b.item.is_resurrectable_session();
+
             match (a_is_session, b_is_session) {
                 (true, false) => std::cmp::Ordering::Less,  // a (session) comes first
                 (false, true) => std::cmp::Ordering::Greater, // b (session) comes first
@@ -180,6 +180,10 @@ impl SearchEngine {
             SessionItem::ExistingSession { name, directory, is_current } => {
                 let prefix = if *is_current { "● " } else { "○ " };
                 format!("{}{} ({})", prefix, name, directory)
+            }
+            SessionItem::ResurrectableSession {name, duration} => {
+                // For resurrectable sessions, we show the name and duration
+                format!("↺ {} (created {} ago)", name, humantime::format_duration(*duration))
             }
             SessionItem::Directory { path, .. } => {
                 // For directories, we search the full path as displayed


### PR DESCRIPTION
Fixes: https://github.com/liam-mackie/zsm/issues/7

This adds an option to enable showing resurrectable sessions in the list. To enable, add the `show_resurrectable_sessions` configuration key with the value `true`. 