### PR TITLE
feat: add show_all_sessions option, session stability tracking, ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Run tests
-        run: cargo test
+        run: cargo test --target x86_64-unknown-linux-gnu
 
   build-wasm:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Run tests
+        run: cargo test
+
+  build-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-wasip1
+
+      - name: Build WASM plugin
+        run: cargo build --target wasm32-wasip1
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-wasip1
+          components: clippy
+
+      - name: Run clippy
+        run: cargo clippy --target wasm32-wasip1 -- -D warnings
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ZSM (Zoxide Session Manager) is a Zellij plugin written in Rust that integrates zoxide (smart directory navigation) with Zellij session management. It compiles to WebAssembly and runs inside Zellij.
+
+## Build Commands
+
+```bash
+# Build for development (debug mode)
+cargo build --target wasm32-wasip1
+
+# Build for release
+cargo build --target wasm32-wasip1 --release
+
+# Add WASM target if not installed
+rustup target add wasm32-wasip1
+```
+
+Output locations:
+- Debug: `target/wasm32-wasip1/debug/zsm.wasm`
+- Release: `target/wasm32-wasip1/release/zsm.wasm`
+
+## Development Workflow
+
+Start the plugin development layout (includes hot-reload keybinding):
+```bash
+zellij -l zellij.kdl
+```
+- Press `Alt+R` to reload the plugin after rebuilding
+- Re-launch plugin manually: `zellij action launch-or-focus-plugin file:target/wasm32-wasip1/debug/zsm.wasm`
+
+Alternative with watchexec:
+```bash
+watchexec --exts rs -- 'cargo build --target wasm32-wasip1; zellij action start-or-reload-plugin file:target/wasm32-wasip1/debug/zsm.wasm'
+```
+
+## Architecture
+
+### Core Modules
+
+- **`main.rs`** - Plugin entry point. Implements `ZellijPlugin` trait, handles Zellij events (key input, permissions, session updates), and processes zoxide output. Contains smart session naming logic.
+
+- **`state.rs`** - `PluginState` struct holds all plugin state: config, session manager, zoxide directories, search engine, and UI state. Orchestrates key handling between screens (Main vs NewSession).
+
+- **`config.rs`** - Plugin configuration parsed from Zellij layout options (default_layout, session_separator, show_resurrectable_sessions, show_all_sessions, base_paths).
+
+### Session Module (`session/`)
+
+- **`manager.rs`** - `SessionManager` handles session operations: tracking existing/resurrectable sessions, generating incremented names (e.g., `project.2`), and executing actions (switch/delete sessions).
+
+- **`types.rs`** - `SessionItem` enum (ExistingSession, ResurrectableSession, Directory) and `SessionAction` enum for session operations.
+
+### Zoxide Module (`zoxide/`)
+
+- **`directory.rs`** - `ZoxideDirectory` struct: ranking score, directory path, generated session name.
+
+- **`search.rs`** - `SearchEngine` for fuzzy-finding directories/sessions using `fuzzy-matcher` crate.
+
+### UI Module (`ui/`)
+
+- **`renderer.rs`** - `PluginRenderer` handles all terminal rendering. Renders main list, new session screen, search results, and deletion confirmations.
+
+- **`components.rs`** - UI color utilities.
+
+- **`theme.rs`** - Theme/palette handling.
+
+### Other
+
+- **`new_session_info.rs`** - State for new session creation screen (name input, folder selection, layout selection).
+
+## Key Concepts
+
+**Smart Session Naming**: The plugin generates session names from directory paths, handling conflicts (adds parent context), nested directories, and truncation (max 29 chars due to Unix socket path limits).
+
+**Two-Screen UI**: Main screen shows directory list with fuzzy search; NewSession screen handles session name/folder/layout configuration.
+
+**Filepicker Integration**: Communicates with Zellij's filepicker plugin via `pipe_message_to_plugin` for folder selection.
+
+**Session Stability**: Zellij sends inconsistent `SessionUpdate` events that can omit sessions temporarily. The `SessionManager` uses stability tracking with a missing-count threshold (3 updates) before removing sessions from the UI, preventing flickering.
+
+## Testing
+
+Tests must run on the **native target**, not WASM (WASM binaries can't execute directly):
+
+```bash
+# Run tests (uses native target automatically when not cross-compiling)
+cargo test
+
+# Or explicitly specify target
+cargo test --target aarch64-apple-darwin
+```
+
+Note: `SessionInfo` from `zellij-tile` has many required fields. See `manager.rs` test helper `make_session()` for how to construct test instances.
+
+## CI
+
+GitHub Actions workflow (`.github/workflows/ci.yml`) runs on PRs and pushes to main:
+- `test` - Runs unit tests on native target
+- `build-wasm` - Verifies WASM compilation
+- `clippy` - Lints with `-D warnings`
+- `fmt` - Checks formatting

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,8 @@ pub struct Config {
     pub show_resurrectable_sessions: bool,
     /// Base paths to strip from directory names when generating session names
     pub base_paths: Vec<String>,
+    /// Whether to show all sessions, not just those matching zoxide directories
+    pub show_all_sessions: bool,
 }
 
 impl Default for Config {
@@ -20,6 +22,7 @@ impl Default for Config {
             session_separator: ".".to_string(),
             show_resurrectable_sessions: false,
             base_paths: Vec::new(),
+            show_all_sessions: false,
         }
     }
 }
@@ -46,7 +49,11 @@ impl Config {
                         .filter(|p| !p.is_empty())
                         .collect()
                 })
-                .unwrap_or_else(Vec::new),
+                .unwrap_or_default(),
+            show_all_sessions: config
+                .get("show_all_sessions")
+                .map(|v| v == "true")
+                .unwrap_or(false),
         }
     }
 }

--- a/src/new_session_info.rs
+++ b/src/new_session_info.rs
@@ -11,16 +11,11 @@ pub struct NewSessionInfo {
     pub new_session_folder: Option<PathBuf>,
 }
 
-#[derive(Eq, PartialEq)]
+#[derive(Default, Eq, PartialEq)]
 enum EnteringState {
+    #[default]
     EnteringName,
     EnteringLayoutSearch,
-}
-
-impl Default for EnteringState {
-    fn default() -> Self {
-        EnteringState::EnteringName
-    }
 }
 
 impl NewSessionInfo {
@@ -163,19 +158,19 @@ impl NewSessionInfo {
 
                     match layout_info {
                         Some(layout) => {
-                            let cwd = self.new_session_folder.as_ref().map(|c| PathBuf::from(c));
+                            let cwd = self.new_session_folder.clone();
                             switch_session_with_layout(new_session_name, layout, cwd);
                         }
                         None => {
                             // Default layout not found, create without layout but with folder
-                            let cwd = self.new_session_folder.as_ref().map(|c| PathBuf::from(c));
+                            let cwd = self.new_session_folder.clone();
                             switch_session_with_cwd(new_session_name, cwd);
                         }
                     }
                 }
                 None => {
                     // No default layout configured, create without layout but with folder
-                    let cwd = self.new_session_folder.as_ref().map(|c| PathBuf::from(c));
+                    let cwd = self.new_session_folder.clone();
                     switch_session_with_cwd(new_session_name, cwd);
                 }
             }
@@ -198,11 +193,11 @@ impl NewSessionInfo {
                 if new_session_name != current_session_name.as_ref().map(|s| s.as_str()) {
                     match new_session_layout {
                         Some(new_session_layout) => {
-                            let cwd = self.new_session_folder.as_ref().map(|c| PathBuf::from(c));
+                            let cwd = self.new_session_folder.clone();
                             switch_session_with_layout(new_session_name, new_session_layout, cwd)
                         }
                         None => {
-                            let cwd = self.new_session_folder.as_ref().map(|c| PathBuf::from(c));
+                            let cwd = self.new_session_folder.clone();
                             switch_session_with_cwd(new_session_name, cwd);
                         }
                     }
@@ -311,7 +306,7 @@ impl NewSessionInfo {
             let matcher = SkimMatcherV2::default().use_cache(true);
             for layout_info in &self.layout_list.layout_list {
                 if let Some((score, indices)) =
-                    matcher.fuzzy_indices(&layout_info.name(), &self.layout_list.layout_search_term)
+                    matcher.fuzzy_indices(layout_info.name(), &self.layout_list.layout_search_term)
                 {
                     matches.push(LayoutSearchResult {
                         layout_info: layout_info.clone(),

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -1,6 +1,10 @@
 use crate::session::types::SessionAction;
+use std::collections::HashMap;
 use std::time::Duration;
 use zellij_tile::prelude::{delete_dead_session, kill_sessions, switch_session, SessionInfo};
+
+/// Number of consecutive updates a session must be missing before we remove it
+const MISSING_THRESHOLD: u8 = 3;
 
 /// Manages session operations and state
 #[derive(Debug, Default)]
@@ -11,20 +15,101 @@ pub struct SessionManager {
     pending_deletion: Option<String>,
     /// Resurrectable sessions
     resurrectable_sessions: Vec<(String, Duration)>,
+    /// Tracks how many consecutive updates each session has been missing
+    /// Key is lowercase session name for case-insensitive matching
+    missing_counts: HashMap<String, u8>,
 }
 
 impl SessionManager {
-    /// Update the session list with new session information
-    pub fn update_sessions(&mut self, sessions: Vec<SessionInfo>) {
-        self.sessions = sessions;
+    /// Update session list with stability tracking
+    /// Returns true if the visible session list changed
+    pub fn update_sessions_stable(&mut self, new_sessions: Vec<SessionInfo>) -> bool {
+        let mut changed = false;
+
+        // Build a set of session names from the new update (lowercase for comparison)
+        let new_session_names: HashMap<String, &SessionInfo> = new_sessions
+            .iter()
+            .map(|s| (s.name.to_lowercase(), s))
+            .collect();
+
+        // Check for sessions that are in the new list - reset their missing count
+        // and add any genuinely new sessions
+        for new_session in &new_sessions {
+            let key = new_session.name.to_lowercase();
+            self.missing_counts.remove(&key);
+
+            // Check if this is a new session we haven't seen before
+            let exists = self.sessions.iter().any(|s| s.name.to_lowercase() == key);
+            if !exists {
+                // New session - add it
+                self.sessions.push(new_session.clone());
+                changed = true;
+            } else {
+                // Update existing session info (e.g., is_current_session flag)
+                if let Some(existing) = self
+                    .sessions
+                    .iter_mut()
+                    .find(|s| s.name.to_lowercase() == key)
+                {
+                    if existing.is_current_session != new_session.is_current_session {
+                        existing.is_current_session = new_session.is_current_session;
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        // Check for sessions that are missing from the new list
+        let mut sessions_to_remove = Vec::new();
+        for session in &self.sessions {
+            let key = session.name.to_lowercase();
+            if !new_session_names.contains_key(&key) {
+                // Session is missing - increment its missing count
+                let count = self.missing_counts.entry(key.clone()).or_insert(0);
+                *count += 1;
+
+                if *count >= MISSING_THRESHOLD {
+                    // Session has been missing long enough - remove it
+                    sessions_to_remove.push(key);
+                    changed = true;
+                }
+            }
+        }
+
+        // Remove sessions that have been missing for too long
+        for key in sessions_to_remove {
+            self.sessions.retain(|s| s.name.to_lowercase() != key);
+            self.missing_counts.remove(&key);
+        }
+
+        changed
     }
 
-    /// Update the resurrectable sessions
-    pub fn update_resurrectable_sessions(
+    /// Update resurrectable sessions with stability tracking
+    /// Returns true if the visible list changed
+    pub fn update_resurrectable_stable(
         &mut self,
-        resurrectable_sessions: Vec<(String, Duration)>,
-    ) {
-        self.resurrectable_sessions = resurrectable_sessions;
+        new_resurrectable: Vec<(String, Duration)>,
+    ) -> bool {
+        // For resurrectable sessions, we use simpler logic:
+        // Just check if the set of names changed (case-insensitive)
+        let mut current_names: Vec<String> = self
+            .resurrectable_sessions
+            .iter()
+            .map(|(name, _)| name.to_lowercase())
+            .collect();
+        let mut new_names: Vec<String> = new_resurrectable
+            .iter()
+            .map(|(name, _)| name.to_lowercase())
+            .collect();
+
+        current_names.sort();
+        new_names.sort();
+
+        let changed = current_names != new_names;
+        // Always update to get fresh durations
+        self.resurrectable_sessions = new_resurrectable;
+        changed
     }
 
     /// Get all sessions
@@ -108,7 +193,145 @@ impl SessionManager {
             "{}{}{}",
             base_name,
             separator,
-            uuid::Uuid::new_v4().to_string()[..8].to_string()
+            &uuid::Uuid::new_v4().to_string()[..8]
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_session(name: &str, is_current: bool) -> SessionInfo {
+        use std::collections::BTreeMap;
+        use zellij_tile::prelude::PaneManifest;
+        SessionInfo {
+            name: name.to_string(),
+            is_current_session: is_current,
+            tabs: vec![],
+            panes: PaneManifest {
+                panes: std::collections::HashMap::new(),
+            },
+            connected_clients: 0,
+            available_layouts: vec![],
+            plugins: BTreeMap::new(),
+            tab_history: BTreeMap::new(),
+            web_client_count: 0,
+            web_clients_allowed: true,
+        }
+    }
+
+    #[test]
+    fn test_new_session_added_immediately() {
+        let mut manager = SessionManager::default();
+
+        let changed = manager.update_sessions_stable(vec![make_session("test", false)]);
+
+        assert!(changed);
+        assert_eq!(manager.sessions().len(), 1);
+        assert_eq!(manager.sessions()[0].name, "test");
+    }
+
+    #[test]
+    fn test_session_not_removed_on_single_missing_update() {
+        let mut manager = SessionManager::default();
+
+        // Add a session
+        manager.update_sessions_stable(vec![make_session("test", false)]);
+
+        // Session disappears for one update
+        let changed = manager.update_sessions_stable(vec![]);
+
+        // Should NOT be removed yet (needs MISSING_THRESHOLD updates)
+        assert!(!changed);
+        assert_eq!(manager.sessions().len(), 1);
+    }
+
+    #[test]
+    fn test_session_removed_after_threshold_missing_updates() {
+        let mut manager = SessionManager::default();
+
+        // Add a session
+        manager.update_sessions_stable(vec![make_session("test", false)]);
+
+        // Session disappears for MISSING_THRESHOLD updates
+        for i in 0..MISSING_THRESHOLD {
+            let changed = manager.update_sessions_stable(vec![]);
+            if i < MISSING_THRESHOLD - 1 {
+                assert!(!changed, "Should not report changed before threshold");
+                assert_eq!(manager.sessions().len(), 1, "Session should still exist");
+            } else {
+                assert!(changed, "Should report changed when removed");
+                assert_eq!(manager.sessions().len(), 0, "Session should be removed");
+            }
+        }
+    }
+
+    #[test]
+    fn test_session_reappearing_resets_missing_count() {
+        let mut manager = SessionManager::default();
+
+        // Add a session
+        manager.update_sessions_stable(vec![make_session("test", false)]);
+
+        // Session disappears for 2 updates (less than threshold)
+        manager.update_sessions_stable(vec![]);
+        manager.update_sessions_stable(vec![]);
+
+        // Session reappears
+        let changed = manager.update_sessions_stable(vec![make_session("test", false)]);
+        assert!(!changed); // No visible change
+        assert_eq!(manager.sessions().len(), 1);
+
+        // Now it disappears again - counter should have been reset
+        let changed = manager.update_sessions_stable(vec![]);
+        assert!(!changed);
+        assert_eq!(manager.sessions().len(), 1); // Still there after 1 missing
+    }
+
+    #[test]
+    fn test_is_current_session_update_triggers_change() {
+        let mut manager = SessionManager::default();
+
+        // Add a non-current session
+        manager.update_sessions_stable(vec![make_session("test", false)]);
+
+        // Update it to be current
+        let changed = manager.update_sessions_stable(vec![make_session("test", true)]);
+
+        assert!(changed);
+        assert!(manager.sessions()[0].is_current_session);
+    }
+
+    #[test]
+    fn test_resurrectable_name_change_triggers_update() {
+        let mut manager = SessionManager::default();
+
+        // Add initial resurrectable sessions
+        let changed = manager
+            .update_resurrectable_stable(vec![("session1".to_string(), Duration::from_secs(60))]);
+        assert!(changed);
+
+        // Same sessions - no change
+        let changed = manager
+            .update_resurrectable_stable(vec![("session1".to_string(), Duration::from_secs(120))]);
+        assert!(!changed);
+
+        // Different sessions - change
+        let changed = manager
+            .update_resurrectable_stable(vec![("session2".to_string(), Duration::from_secs(60))]);
+        assert!(changed);
+    }
+
+    #[test]
+    fn test_resurrectable_case_insensitive_comparison() {
+        let mut manager = SessionManager::default();
+
+        manager.update_resurrectable_stable(vec![("Session".to_string(), Duration::from_secs(60))]);
+
+        // Same name different case - should NOT trigger change
+        let changed = manager
+            .update_resurrectable_stable(vec![("session".to_string(), Duration::from_secs(60))]);
+        assert!(!changed);
     }
 }

--- a/src/ui/components.rs
+++ b/src/ui/components.rs
@@ -28,7 +28,7 @@ pub fn render_new_session_block(
         let long_instruction = "when done, blank for random";
         let new_session_name = new_session_info.name();
         if max_cols_of_new_session_block > 70 {
-            let session_name_text = Text::new(&format!(
+            let session_name_text = Text::new(format!(
                 "{} {}_ (<ENTER> {})",
                 prompt, new_session_name, long_instruction
             ))
@@ -44,7 +44,7 @@ pub fn render_new_session_block(
             );
             print_text_with_coordinates(session_name_text, x, y + 1, None, None);
         } else {
-            let session_name_text = Text::new(&format!("{} {}_ <ENTER>", prompt, new_session_name))
+            let session_name_text = Text::new(format!("{} {}_ <ENTER>", prompt, new_session_name))
                 .color_range(3, ..prompt.len())
                 .color_range(
                     0,
@@ -60,7 +60,7 @@ pub fn render_new_session_block(
             new_session_info.name()
         };
         let prompt = "New session name:";
-        let session_name_text = Text::new(&format!(
+        let session_name_text = Text::new(format!(
             "{} {} (Ctrl+<R> to correct)",
             prompt, new_session_name
         ))
@@ -139,7 +139,7 @@ pub fn render_layout_selection_list(
                     .color_range(0, layout_name.len() + 1..)
                     .color_indices(3, indices)
             } else {
-                Text::new(format!("{}", layout_name))
+                Text::new(layout_name.to_string())
                     .color_range(1, ..)
                     .color_indices(3, indices)
             };
@@ -170,7 +170,7 @@ pub fn render_new_session_folder_prompt(
             let short_folder_prompt = "New session folder:";
             let folder_path = folder.to_string_lossy();
             if max_cols > short_folder_prompt.len() + folder_path.len() + 40 {
-                let folder_text = Text::new(&format!(
+                let folder_text = Text::new(format!(
                     "{} {} (Ctrl+<f> to change, Ctrl+<c> to clear)",
                     short_folder_prompt, folder_path
                 ))
@@ -193,7 +193,7 @@ pub fn render_new_session_folder_prompt(
                 print_text_with_coordinates(folder_text, x, y + 1, None, None);
             } else {
                 let folder_text =
-                    Text::new(&format!("{} {} Ctrl+<f>", short_folder_prompt, folder_path))
+                    Text::new(format!("{} {} Ctrl+<f>", short_folder_prompt, folder_path))
                         .color_range(2, ..short_folder_prompt.len())
                         .color_range(
                             1,
@@ -206,7 +206,7 @@ pub fn render_new_session_folder_prompt(
         }
         None => {
             let folder_prompt = "New session folder (optional):";
-            let folder_text = Text::new(&format!("{} Ctrl+<f> to select", folder_prompt))
+            let folder_text = Text::new(format!("{} Ctrl+<f> to select", folder_prompt))
                 .color_range(2, ..folder_prompt.len())
                 .color_range(3, folder_prompt.len() + 1..folder_prompt.len() + 9);
             print_text_with_coordinates(folder_text, x, y + 1, None, None);

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -326,7 +326,7 @@ impl PluginRenderer {
             "If this is a resurrectable session, it will be deleted. This action cannot be undone.";
         let prompt = "Press 'y' to confirm, 'n' or Esc to cancel";
 
-        let dialog_lines = vec![
+        let dialog_lines = [
             "┌".to_string() + &"─".repeat(dialog_width.saturating_sub(2)) + "┐",
             format!(
                 "│{:^width$}│",

--- a/src/zoxide/search.rs
+++ b/src/zoxide/search.rs
@@ -112,7 +112,7 @@ impl SearchEngine {
             if *selected == self.results.len().saturating_sub(1) {
                 *selected = 0;
             } else {
-                *selected = *selected + 1;
+                *selected += 1;
             }
         } else if !self.results.is_empty() {
             self.selected_index = Some(0);


### PR DESCRIPTION
  Add show_all_sessions config option to display all active sessions,
  not just those matching zoxide directories. Useful for seeing sessions
  created outside of zsm.

  Add stability tracking to prevent UI flickering from Zellij's
  inconsistent session updates. Sessions must be missing for 3
  consecutive updates before removal, and new sessions appear
  immediately.

  Changes:
  - Add show_all_sessions config option (default: false)
  - Add update_sessions_stable() with missing-count tracking
  - Add find_matching_zoxide_dir() helper to reduce code duplication
  - Add unit tests for stability tracking logic
  - Add GitHub Actions CI workflow (test, build-wasm, clippy, fmt)
  - Fix all clippy warnings and formatting issues